### PR TITLE
Margin right mobile fix

### DIFF
--- a/src/config/theme/components/cases.ts
+++ b/src/config/theme/components/cases.ts
@@ -10,7 +10,7 @@ const cases = {
     },
     mainStat: {
       gridColumn: ['span 1', 'span 3'],
-      padding: '24px 12px',
+      px: [2, 3],
     },
     secondaryStat: {
       gridColumn: ['span 1', 'span 2'],

--- a/src/config/theme/components/cases.ts
+++ b/src/config/theme/components/cases.ts
@@ -3,10 +3,14 @@ const cases = {
     container: {
       display: 'grid',
       gridGap: 5,
-      gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(6, 1fr)'],
+      gridTemplateColumns: [
+        'repeat(2, minmax(0, 1fr))',
+        'repeat(6, minmax(0, 1fr))',
+      ],
     },
     mainStat: {
       gridColumn: ['span 1', 'span 3'],
+      padding: '24px 12px',
     },
     secondaryStat: {
       gridColumn: ['span 1', 'span 2'],

--- a/src/config/theme/text.ts
+++ b/src/config/theme/text.ts
@@ -4,7 +4,7 @@ const text = {
       'Helvetica, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
     heading: 'inherit',
   },
-  fontSizes: [12, 14, 16, 20, 24, 32, 48, 64, 96],
+  fontSizes: [12, 14, 16, 20, 24, 32, 48, 56, 64],
   fontWeights: {
     body: 400,
     heading: 700,


### PR DESCRIPTION
Hi! :)
I use this site on my phone on a daily basis and there's a glitch that triggers my TOC; here's a fix.

- Lowered font sizes to use more realistic sizes
- Lowered horizontal padding for main statistic cards
- Added minmax fix to grid layout to avoid cards having weird sizes
- We might need to tweak this UI again when the numbers grow